### PR TITLE
add ability to set options

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,34 @@ Motion::Layout.new do |layout|
 end
 ```
 
+### Layout Options
+
+The default layout options will be `NSLayoutFormatAlignAllCenterY` for a horizontal format and `NSLayoutFormatAlignAllCenterX` for a vertical format. If you need to override this pass the layout options as a second parameter.
+
+``` ruby
+Motion::Layout.new do |layout|
+  ...
+  layout.vertical "[version]-|"
+  layout.horizontal "[version]-5-[version_number]-|", NSLayoutFormatAlignAllBaseline
+end
+```
+
+Or if you get a warning about not being able to simultaneously satisfy constraints that looks something like...
+
+```
+Will attempt to recover by breaking constraint
+<NSLayoutConstraint:0x952a320 UILabel:0x951ecd0.centerX == UIView:0x95199b0.centerX>
+```
+
+then you can clear the default options with a 0
+
+``` ruby
+Motion::Layout.new do |layout|
+  ...
+  layout.vertical "[operator]-[separator]", 0
+end
+```
+
 ## TODO
 
 * Support finer grained constraints
@@ -72,3 +100,4 @@ I couldn't figure out how to test this automatically. Run `bundle` to get the ge
 ## License
 
 MIT. See `LICENSE`.
+

--- a/example/app/timer_controller.rb
+++ b/example/app/timer_controller.rb
@@ -25,12 +25,9 @@ class TimerController < UIViewController
   attr_reader :timer
 
   def viewDidLoad
-    @state = UILabel.new
-    @state.font = UIFont.systemFontOfSize(30)
-    @state.text = 'Tap to start'
-    @state.textAlignment = UITextAlignmentCenter
-    @state.textColor = UIColor.whiteColor
-    @state.backgroundColor = UIColor.clearColor
+    @state = buildLabelWithText('Tap to start', ofSize: 30)
+    @version = buildLabelWithText('version', ofSize: 14)
+    @versionNumber = buildLabelWithText('0.0.1', ofSize: 19)
 
     @action = UIButton.buttonWithType(UIButtonTypeRoundedRect)
     @action.setTitle('Start', forState:UIControlStateNormal)
@@ -39,11 +36,13 @@ class TimerController < UIViewController
 
     Motion::Layout.new do |layout|
       layout.view view
-      layout.subviews "state" => @state, "action" => @action
+      layout.subviews "state" => @state, "action" => @action, "version" => @version, "version_number" => @versionNumber
       layout.metrics "top" => 200, "margin" => 20, "height" => 40
       layout.vertical "|-top-[state(==height)]-margin-[action(==height)]"
+      layout.vertical "[version]-|"
       layout.horizontal "|-margin-[state]-margin-|"
       layout.horizontal "|-margin-[action]-margin-|"
+      layout.horizontal "[version]-5-[version_number]-|", NSLayoutFormatAlignAllBaseline
     end
   end
 
@@ -60,5 +59,15 @@ class TimerController < UIViewController
 
   def timerFired
     @state.text = "%.1f" % (@duration += 0.1)
+  end
+
+  def buildLabelWithText(text, ofSize: size)
+    label = UILabel.new
+    label.font = UIFont.systemFontOfSize(size)
+    label.text = text
+    label.textAlignment = UITextAlignmentCenter
+    label.textColor = UIColor.whiteColor
+    label.backgroundColor = UIColor.clearColor
+    label
   end
 end

--- a/lib/motion-layout/layout.rb
+++ b/lib/motion-layout/layout.rb
@@ -21,12 +21,12 @@ module Motion
       @view = view
     end
 
-    def horizontal(horizontal)
-      @horizontals << horizontal
+    def horizontal(horizontal, options = NSLayoutFormatAlignAllCenterY)
+      @horizontals << [horizontal, options]
     end
 
-    def vertical(vertical)
-      @verticals << vertical
+    def vertical(vertical, options = NSLayoutFormatAlignAllCenterX)
+      @verticals << [vertical, options]
     end
 
     private
@@ -38,11 +38,11 @@ module Motion
       end
 
       constraints = []
-      constraints += @verticals.map do |vertical|
-        NSLayoutConstraint.constraintsWithVisualFormat("V:#{vertical}", options:NSLayoutFormatAlignAllCenterX, metrics:@metrics, views:@subviews)
+      constraints += @verticals.map do |layout, options|
+        NSLayoutConstraint.constraintsWithVisualFormat("V:#{layout}", options:options, metrics:@metrics, views:@subviews)
       end
-      constraints += @horizontals.map do |horizontal|
-        NSLayoutConstraint.constraintsWithVisualFormat("H:#{horizontal}", options:NSLayoutFormatAlignAllCenterY, metrics:@metrics, views:@subviews)
+      constraints += @horizontals.map do |layout, options|
+        NSLayoutConstraint.constraintsWithVisualFormat("H:#{layout}", options:options, metrics:@metrics, views:@subviews)
       end
 
       @view.addConstraints(constraints.flatten)


### PR DESCRIPTION
I left the default options of NSLayoutFormatAlignAllCenterY and X, just added the ability to override them as they were conflicting with a layout I was trying to do

```
Unable to simultaneously satisfy constraints.
    Probably at least one of the constraints in the following list is one you don't want. Try this: (1) look at each constraint and try to figure out which you don't expect; (2) find the code that added the unwanted constraint or constraints and fix it. (Note: If you're seeing NSAutoresizingMaskLayoutConstraints that you don't understand, refer to the documentation for the UIView property translatesAutoresizingMaskIntoConstraints)
(
    "<NSAutoresizingMaskLayoutConstraint:0x9535c90 h=--- v=--- H:[UIWindow:0x93b0000(320)]>",
    "<NSAutoresizingMaskLayoutConstraint:0x9534640 h=-&- v=-&- UIView:0x95251f0.width == UIWindow:0x93b0000.width>",
    "<NSLayoutConstraint:0x952aa80 H:[UIView:0x95199b0]-(NSSpace(20))-|   (Names: '|':UIView:0x95251f0 )>",
    "<NSLayoutConstraint:0x952aa00 H:|-(NSSpace(20))-[UIView:0x95199b0]   (Names: '|':UIView:0x95251f0 )>",
    "<NSLayoutConstraint:0x952a6f0 H:[UILabel:0x951ecd0(50)]>",
    "<NSLayoutConstraint:0x952a680 H:|-(NSSpace(20))-[UILabel:0x951ecd0]   (Names: '|':UIView:0x95251f0 )>",
    "<NSLayoutConstraint:0x952a320 UILabel:0x951ecd0.centerX == UIView:0x95199b0.centerX>"
)

Will attempt to recover by breaking constraint
<NSLayoutConstraint:0x952a320 UILabel:0x951ecd0.centerX == UIView:0x95199b0.centerX>
```
