### PR TITLE
Use symbols as keys for Metrics and Subviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ And here's an example you can run right inside this repo, the Time app converted
 ``` ruby
 Motion::Layout.new do |layout|
   layout.view view
-  layout.subviews "state" => @state, "action" => @action
+  layout.subviews state: @state, action: @action
   layout.metrics "top" => 200, "margin" => 20, "height" => 40
   layout.vertical "|-top-[state(==height)]-margin-[action(==height)]"
   layout.horizontal "|-margin-[state]-margin-|"

--- a/lib/motion-layout/layout.rb
+++ b/lib/motion-layout/layout.rb
@@ -10,11 +10,11 @@ module Motion
     end
 
     def metrics(metrics)
-      @metrics = metrics
+      @metrics = Hash[metrics.keys.map(&:to_s).zip(metrics.values)]
     end
 
     def subviews(subviews)
-      @subviews = subviews
+      @subviews = Hash[subviews.keys.map(&:to_s).zip(subviews.values)]
     end
 
     def view(view)


### PR DESCRIPTION
Since NSLayoutConstraints doesn't accept symbols as keys for Metrics nor Subviews,
I created this pull request to fix it. it's nothing special only a little rubyfication

``` ruby
Motion::Layout.new do |layout|
  layout.view view
  layout.subviews state: @state, action: @action
  layout.metrics top: 200, margin: 20, height: 40
  layout.vertical "|-top-[state(==height)]-margin-[action(==height)]"
  layout.horizontal "|-margin-[state]-margin-|"
  layout.horizontal "|-margin-[action]-margin-|"
end
```
