### PR TITLE
Add ability to override constraint options

### DIFF
--- a/lib/motion-layout/layout.rb
+++ b/lib/motion-layout/layout.rb
@@ -21,12 +21,12 @@ module Motion
       @view = view
     end
 
-    def horizontal(horizontal)
-      @horizontals << horizontal
+    def horizontal(horizontal, options = NSLayoutFormatAlignAllCenterY)
+      @horizontals << [horizontal, options]
     end
 
-    def vertical(vertical)
-      @verticals << vertical
+    def vertical(vertical, options = NSLayoutFormatAlignAllCenterX)
+      @verticals << [vertical, options]
     end
 
     private
@@ -38,11 +38,11 @@ module Motion
       end
 
       constraints = []
-      constraints += @verticals.map do |vertical|
-        NSLayoutConstraint.constraintsWithVisualFormat("V:#{vertical}", options:NSLayoutFormatAlignAllCenterX, metrics:@metrics, views:@subviews)
+      constraints += @verticals.map do |vertical, options|
+        NSLayoutConstraint.constraintsWithVisualFormat("V:#{vertical}", options: options, metrics:@metrics, views:@subviews)
       end
-      constraints += @horizontals.map do |horizontal|
-        NSLayoutConstraint.constraintsWithVisualFormat("H:#{horizontal}", options:NSLayoutFormatAlignAllCenterY, metrics:@metrics, views:@subviews)
+      constraints += @horizontals.map do |horizontal, options|
+        NSLayoutConstraint.constraintsWithVisualFormat("H:#{horizontal}", options: options, metrics:@metrics, views:@subviews)
       end
 
       @view.addConstraints(constraints.flatten)


### PR DESCRIPTION
Assuming that we always want to use NSLayoutFormatAlignAllCenterX/Y causes certain layouts to become impossible to create. This minor change adds the ability to optionally pass the options for each constraint individually, as so:

```
    layout.vertical '|-padding-[headline]->=0-[byline]-padding-|', NSLayoutFormatAlignAllLeft
    layout.horizontal '|-[headline]-|'
```

The default behavior is unchanged, and this change should be fully backwards compatible.
