### PR TITLE
Add options

### DIFF
--- a/lib/motion-layout/layout.rb
+++ b/lib/motion-layout/layout.rb
@@ -33,7 +33,7 @@ module Motion
 
     private
 
-    def resolve_opts(opt)
+    def resolve_options(opt)
       opt_hash = {
         left: NSLayoutFormatAlignAllLeft,
         right: NSLayoutFormatAlignAllRight,

--- a/lib/motion-layout/layout.rb
+++ b/lib/motion-layout/layout.rb
@@ -53,11 +53,12 @@ module Motion
         else
           raise "invalid opt: #{x.to_s.downcase}"
         end
-	  end
+      end
     end
 
     def strain
       @subviews.values.each do |subview|
+        next if @view == subview # you wouldn't believe the mess it would create
         subview.translatesAutoresizingMaskIntoConstraints = false
         @view.addSubview(subview)
       end


### PR DESCRIPTION
Yet another way of setting options (turns out I'm not the only one needing this).

My approach allows for string/symbol shortcuts for option names.

Oh, and no, I'm not going to be adding readme and whatnot; mainly because @qrush ignores pull requests for 3 months so it'd be waste of time.

I'm just posting this in case someone looks in open pull requests and finds this helpful. I'll be using my local `add-options` branch, thankyouverymuch.
