### PR TITLE
Add options to Layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ Motion::Layout.new do |layout|
   layout.horizontal "|-margin-[action]-margin-|"
 end
 ```
+### Layout Options
+
+Check Motion::Layout::OPTIONS for available options. The default layout options is 0, which is same as [NSLayoutConstraint constraintsWithVisualFormat:options:mertics:views:]. Check [document](https://developer.apple.com/library/ios/DOCUMENTATION/AppKit/Reference/NSLayoutConstraint_Class/NSLayoutConstraint/NSLayoutConstraint.html#//apple_ref/occ/clm/NSLayoutConstraint/constraintsWithVisualFormat:options:metrics:views:) for meaning of each options.
+
+``` ruby
+Motion::Layout.new do |layout|
+  ...
+  layout.vertical "[version]-|"
+  layout.horizontal "[version]-5-[version_number]-|", :baseline
+end
+```
 
 ## TODO
 

--- a/example/Rakefile
+++ b/example/Rakefile
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 $:.unshift("/Library/RubyMotion/lib")
-require 'motion/project'
+require 'motion/project/template/ios'
 
 require 'bundler'
 Bundler.setup

--- a/example/app/timer_controller.rb
+++ b/example/app/timer_controller.rb
@@ -37,13 +37,29 @@ class TimerController < UIViewController
     @action.setTitle('Stop', forState:UIControlStateSelected)
     @action.addTarget(self, action:'actionTapped', forControlEvents:UIControlEventTouchUpInside)
 
+    @version = UILabel.new
+    @version.font = UIFont.systemFontOfSize(10)
+    @version.text = 'version'
+    @version.textAlignment = UITextAlignmentRight
+    @version.textColor = UIColor.whiteColor
+    @version.backgroundColor = UIColor.clearColor
+
+    @versionNumber = UILabel.new
+    @versionNumber.font = UIFont.systemFontOfSize(19)
+    @versionNumber.text = '0.1.0'
+    @versionNumber.textAlignment = UITextAlignmentRight
+    @versionNumber.textColor = UIColor.whiteColor
+    @versionNumber.backgroundColor = UIColor.clearColor
+
     Motion::Layout.new do |layout|
       layout.view view
-      layout.subviews "state" => @state, "action" => @action
+      layout.subviews "state" => @state, "action" => @action, "version" => @version, "version_number" => @versionNumber
       layout.metrics "top" => 200, "margin" => 20, "height" => 40
       layout.vertical "|-top-[state(==height)]-margin-[action(==height)]"
+      layout.vertical "[version]|"
       layout.horizontal "|-margin-[state]-margin-|"
       layout.horizontal "|-margin-[action]-margin-|"
+      layout.horizontal "[version]-5-[version_number]|", :baseline
     end
   end
 

--- a/lib/motion-layout/layout.rb
+++ b/lib/motion-layout/layout.rb
@@ -33,7 +33,7 @@ module Motion
 
     private
 
-    def resolve_opts(opt)
+    def resolve_options(opt)
       opt_hash = {
         left: NSLayoutFormatAlignAllLeft,
         right: NSLayoutFormatAlignAllRight,

--- a/lib/motion-layout/layout.rb
+++ b/lib/motion-layout/layout.rb
@@ -1,5 +1,19 @@
 module Motion
   class Layout
+    OPTIONS = {
+      left: NSLayoutFormatAlignAllLeft,
+      right: NSLayoutFormatAlignAllRight,
+      top: NSLayoutFormatAlignAllTop,
+      bottom: NSLayoutFormatAlignAllBottom,
+      leading: NSLayoutFormatAlignAllLeading,
+      trailing: NSLayoutFormatAlignAllTrailing,
+      centerx: NSLayoutFormatAlignAllCenterX,
+      centery: NSLayoutFormatAlignAllCenterY,
+      baseline: NSLayoutFormatAlignAllBaseline,
+      leading_to_trailing: NSLayoutFormatDirectionLeadingToTrailing,
+      left_to_right: NSLayoutFormatDirectionLeftToRight,
+      right_to_left: NSLayoutFormatDirectionRightToLeft
+    }
     def initialize(&block)
       @verticals   = []
       @horizontals = []
@@ -34,21 +48,10 @@ module Motion
     private
 
     def resolve_options(opt)
-      opt_hash = {
-        left: NSLayoutFormatAlignAllLeft,
-        right: NSLayoutFormatAlignAllRight,
-        top: NSLayoutFormatAlignAllTop,
-        bottom: NSLayoutFormatAlignAllBottom,
-        leading: NSLayoutFormatAlignAllLeading,
-        trailing: NSLayoutFormatAlignAllTrailing,
-        centerx: NSLayoutFormatAlignAllCenterX,
-        centery: NSLayoutFormatAlignAllCenterY,
-        baseline: NSLayoutFormatAlignAllBaseline,
-      }
       opt.inject(0) do |m,x|
         if x.kind_of?(Numeric)
           m | x.to_i
-        elsif o = opt_hash[x.to_s.downcase.to_sym]
+        elsif o = OPTIONS[x.to_s.downcase.to_sym]
           m | o
         else
           raise "invalid opt: #{x.to_s.downcase}"

--- a/lib/motion-layout/layout.rb
+++ b/lib/motion-layout/layout.rb
@@ -1,6 +1,7 @@
 module Motion
   class Layout
     OPTIONS = {
+      none: 0,
       left: NSLayoutFormatAlignAllLeft,
       right: NSLayoutFormatAlignAllRight,
       top: NSLayoutFormatAlignAllTop,
@@ -36,12 +37,12 @@ module Motion
     end
 
     def horizontal(horizontal, *options)
-      options = [:centery] if options.empty?
+      options = [:none] if options.empty?
       @horizontals << [horizontal, resolve_options(options)]
     end
 
     def vertical(vertical, *options)
-      options = [:centerx] if options.empty?
+      options = [:none] if options.empty?
       @verticals << [vertical, resolve_options(options)]
     end
 

--- a/lib/motion-layout/layout.rb
+++ b/lib/motion-layout/layout.rb
@@ -53,11 +53,12 @@ module Motion
         else
           raise "invalid opt: #{x.to_s.downcase}"
         end
-	  end
+      end
     end
 
     def strain
       @subviews.values.each do |subview|
+        next if @view == subview # you wouldn't believe the mess it would create
         subview.translatesAutoresizingMaskIntoConstraints = false
         @view.addSubview(subview)
       end


### PR DESCRIPTION
This patch allow user to set options in `NSLayoutConstraint#constraintsWithVisualFormat:options:metrics:views:` with simple symbol (like `:left`, `:right`, `:trailing`... etc), and by default use option 0 (same as that in `NSLayoutConstraint#constraintsWithVisualFormat:options:metrics:views:`).

This patch is necessary because in many use case, the current option `NSLayoutFormatAlignAllCenterX` and `NSLayoutFormatAlignAllCenterY` will cause conflicts.

This is based on @wejn patch, added document and examples, and merge with head. Please consider merging this, thank you!
